### PR TITLE
Make CPP test runnable on macOS with g++

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [macos-latest]
+        python-version: ["3.8"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Python ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install doxygen graphviz
+          brew install doxygen go graphviz
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install doxygen gcc go graphviz
+          brew install doxygen go graphviz
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,20 +48,6 @@ jobs:
         run: |
           brew update
           brew install doxygen gcc go graphviz
-      - name: Set C++ compiler on macOS
-        if: runner.os == 'macOS'
-        run: |
-          # Find the installed GNU g++ from Homebrew
-          if which g++-15 >/dev/null 2>&1; then
-            echo "CXX=g++-15" >> $GITHUB_ENV
-          elif which g++-14 >/dev/null 2>&1; then
-            echo "CXX=g++-14" >> $GITHUB_ENV
-          elif which g++-13 >/dev/null 2>&1; then
-            echo "CXX=g++-13" >> $GITHUB_ENV
-          else
-            echo "Warning: No GNU g++ found, using default g++ (which may be clang++)"
-            echo "CXX=g++" >> $GITHUB_ENV
-          fi
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest, macos-latest
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,15 +7,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest, macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install doxygen go graphviz
+          brew install doxygen gcc go graphviz
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,13 +17,13 @@ jobs:
           - "3.11"
           - "3.12"
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Node
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 20
       - name: Install dependencies
@@ -44,9 +44,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       - uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # 25.1.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install doxygen go graphviz
+          brew install doxygen gcc go graphviz
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,6 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          # Test on macOS with Python 3.10
           - os: macos-latest
             python-version: "3.10"
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.8"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,20 @@ jobs:
         run: |
           brew update
           brew install doxygen gcc go graphviz
+      - name: Set C++ compiler on macOS
+        if: runner.os == 'macOS'
+        run: |
+          # Find the installed GNU g++ from Homebrew
+          if which g++-15 >/dev/null 2>&1; then
+            echo "CXX=g++-15" >> $GITHUB_ENV
+          elif which g++-14 >/dev/null 2>&1; then
+            echo "CXX=g++-14" >> $GITHUB_ENV
+          elif which g++-13 >/dev/null 2>&1; then
+            echo "CXX=g++-13" >> $GITHUB_ENV
+          else
+            echo "Warning: No GNU g++ found, using default g++ (which may be clang++)"
+            echo "CXX=g++" >> $GITHUB_ENV
+          fi
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          # Only test Python 3.8 on macOS to reduce CI time
+          - os: macos-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
           npm install -g jsonld-cli
+      - name: Install Linux packages
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
           sudo apt install -y build-essential doxygen graphviz
+      - name: Install macOS packages
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install doxygen graphviz
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
-          # Only test Python 3.8 on macOS to reduce CI time
+          # Only test Python 3.9 on macOS to reduce CI time
+          # Python 3.8 is EOL and no longer available on macos-latest
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.8"
           - os: macos-latest
             python-version: "3.10"
           - os: macos-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,19 +10,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          # Only test Python 3.9 on macOS to reduce CI time
-          # Python 3.8 is EOL and no longer available on macos-latest
-          - os: macos-latest
-            python-version: "3.8"
+        include:
+          # Test on macOS with Python 3.10
           - os: macos-latest
             python-version: "3.10"
-          - os: macos-latest
-            python-version: "3.11"
-          - os: macos-latest
-            python-version: "3.12"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Python ${{ matrix.python-version }}

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,4 +1,23 @@
-CXX?=g++
+# On macOS, g++ is often an alias to clang++, so try to find GNU g++ from Homebrew
+# Users can still override by setting CXX environment variable
+ifeq ($(shell uname), Darwin)
+    # Try to find GNU g++ from Homebrew (g++-15, g++-14, or g++-13)
+    ifeq ($(shell which g++-15 2>/dev/null),)
+        ifeq ($(shell which g++-14 2>/dev/null),)
+            ifeq ($(shell which g++-13 2>/dev/null),)
+                CXX?=g++
+            else
+                CXX?=g++-13
+            endif
+        else
+            CXX?=g++-14
+        endif
+    else
+        CXX?=g++-15
+    endif
+else
+    CXX?=g++
+endif
 CPPFLAGS=
 CXXFLAGS=
 LDFLAGS=

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,5 +1,9 @@
 ifeq ($(shell uname), Darwin)
-CXX?=clang++
+CXX?=$(shell \
+	if command -v g++-15 >/dev/null 2>&1; then echo g++-15; \
+	elif command -v g++-14 >/dev/null 2>&1; then echo g++-14; \
+	elif command -v g++-13 >/dev/null 2>&1; then echo g++-13; \
+	else echo g++; fi)
 else
 CXX?=g++
 endif

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,19 +1,13 @@
 # On macOS, g++ is often an alias to clang++, so try to find GNU g++ from Homebrew
 # Users can still override by setting CXX environment variable
 ifeq ($(shell uname), Darwin)
-    # Try to find GNU g++ from Homebrew (g++-15, g++-14, or g++-13)
-    ifeq ($(shell which g++-15 2>/dev/null),)
-        ifeq ($(shell which g++-14 2>/dev/null),)
-            ifeq ($(shell which g++-13 2>/dev/null),)
-                CXX?=g++
-            else
-                CXX?=g++-13
-            endif
-        else
-            CXX?=g++-14
-        endif
+    # Find the latest g++ version from Homebrew by listing /opt/homebrew/bin/g++-*
+    # Extract version numbers, sort them, and pick the latest
+    HOMEBREW_GXX := $(shell ls /opt/homebrew/bin/g++-* 2>/dev/null | sed 's/.*g++-//' | sort -rn | head -n1)
+    ifneq ($(HOMEBREW_GXX),)
+        CXX?=g++-$(HOMEBREW_GXX)
     else
-        CXX?=g++-15
+        CXX?=g++
     endif
 else
     CXX?=g++

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,4 +1,4 @@
-CXX=g++
+CXX?=g++
 CPPFLAGS=
 CXXFLAGS=
 LDFLAGS=
@@ -23,8 +23,8 @@ install: lib{{ basename }}.so lib{{ basename }}.a docs
 	# Library
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/lib
 	$(INSTALL) -m 0755 lib{{ basename }}.so $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so.{{ lib_version }}
-	ln -s lib{{ basename }}.so.{{ lib_version }} $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so
-	ln -s lib{{ basename }}.so.{{ lib_version }} $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so.{{ lib_version.split(".")[0] }}
+	ln -sf lib{{ basename }}.so.{{ lib_version }} $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so
+	ln -sf lib{{ basename }}.so.{{ lib_version }} $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so.{{ lib_version.split(".")[0] }}
 
 	$(INSTALL) -m 0644 lib{{ basename }}.a $(DESTDIR)/$(PREFIX)/lib/
 
@@ -48,7 +48,7 @@ install: lib{{ basename }}.so lib{{ basename }}.a docs
 
 	# Documentation
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/share/doc/lib{{ basename }}
-	$(COPY) -dR doc/ $(DESTDIR)/$(PREFIX)/share/doc/lib{{ basename }}/
+	$(COPY) -R doc/ $(DESTDIR)/$(PREFIX)/share/doc/lib{{ basename }}/
 
 %.o: %.cpp
 	@echo " [CC]  $<"
@@ -63,14 +63,20 @@ lib{{ basename }}.a: $(LIB_OBJS)
 	# Combine all object files into a single object file. This is required
 	# otherwise the linker may only include object files that were actually
 	# referenced and the initializers will not run
-	@echo " [LD]  lib{{ basename }}.static.o"
-	$(LD) -relocatable -o lib{{ basename }}.static.o $^
+	@echo " [CXX]  lib{{ basename }}.static.o"
+	$(CXX) -r -o lib{{ basename }}.static.o $^
 	@echo " [AR]  $@"
 	$(AR) rcs $@ lib{{ basename }}.static.o
 
 lib{{ basename }}.so: $(LIB_OBJS)
 	@echo " [LD]  $@"
+ifeq ($(shell uname), Darwin)
+	# macOS ld doesn't support -soname; avoid passing it and use -dynamiclib
+	# Set install_name to @rpath/... so client binaries can locate the library
+	$(CXX) -dynamiclib $(LDFLAGS) -Wl,-install_name,@rpath/lib{{ basename }}.so -o $@ $^
+else
 	$(CXX) -shared -fPIC -Wl,-soname,lib{{ basename }}.so.{{ lib_version.split(".")[0] }} $(LDFLAGS) -o $@ $^
+endif
 
 {{ basename }}-validate: $(VALIDATE_OBJS) lib{{ basename }}.a
 	@echo " [LD]  $@"

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,13 +1,52 @@
 # On macOS, g++ is often an alias to clang++, so try to find GNU g++ from Homebrew
 # Users can still override by setting CXX environment variable
 ifeq ($(shell uname), Darwin)
-    # Find the latest g++ version from Homebrew by listing /opt/homebrew/bin/g++-*
-    # Extract version numbers, sort them, and pick the latest
-    HOMEBREW_GXX := $(shell ls /opt/homebrew/bin/g++-* 2>/dev/null | sed 's/.*g++-//' | sort -rn | head -n1)
-    ifneq ($(HOMEBREW_GXX),)
-        CXX?=g++-$(HOMEBREW_GXX)
+    # Find the latest g++ version from Homebrew using which (works on both Intel and Apple Silicon)
+    # Try versions from 20 down to 10
+    ifeq ($(shell which g++-20 2>/dev/null),)
+        ifeq ($(shell which g++-19 2>/dev/null),)
+            ifeq ($(shell which g++-18 2>/dev/null),)
+                ifeq ($(shell which g++-17 2>/dev/null),)
+                    ifeq ($(shell which g++-16 2>/dev/null),)
+                        ifeq ($(shell which g++-15 2>/dev/null),)
+                            ifeq ($(shell which g++-14 2>/dev/null),)
+                                ifeq ($(shell which g++-13 2>/dev/null),)
+                                    ifeq ($(shell which g++-12 2>/dev/null),)
+                                        ifeq ($(shell which g++-11 2>/dev/null),)
+                                            ifeq ($(shell which g++-10 2>/dev/null),)
+                                                CXX?=g++
+                                            else
+                                                CXX?=g++-10
+                                            endif
+                                        else
+                                            CXX?=g++-11
+                                        endif
+                                    else
+                                        CXX?=g++-12
+                                    endif
+                                else
+                                    CXX?=g++-13
+                                endif
+                            else
+                                CXX?=g++-14
+                            endif
+                        else
+                            CXX?=g++-15
+                        endif
+                    else
+                        CXX?=g++-16
+                    endif
+                else
+                    CXX?=g++-17
+                endif
+            else
+                CXX?=g++-18
+            endif
+        else
+            CXX?=g++-19
+        endif
     else
-        CXX?=g++
+        CXX?=g++-20
     endif
 else
     CXX?=g++

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,18 +1,18 @@
 # On macOS, g++ is often an alias to clang++, so try to find GNU g++ from Homebrew
 # Users can still override by setting CXX environment variable
 ifeq ($(shell uname), Darwin)
-    CXX_DETECTED := $(shell \
-        for v in 20 19 18 17 16 15 14 13 12 11 10; do \
-            if which g++-$$v >/dev/null 2>&1; then \
-                echo g++-$$v; \
-                break; \
-            fi; \
-        done)
-    ifneq ($(CXX_DETECTED),)
-        CXX?=$(CXX_DETECTED)
-    else
-        CXX?=g++
-    endif
+	CXX_DETECTED := $(shell \
+		for v in 20 19 18 17 16 15 14 13 12 11 10; do \
+			if which g++-$$v >/dev/null 2>&1; then \
+				echo g++-$$v; \
+				break; \
+			fi; \
+		done)
+	ifneq ($(CXX_DETECTED),)
+		CXX?=$(CXX_DETECTED)
+	else
+	CXX?=g++
+	endif
 else
     CXX?=g++
 endif
@@ -49,14 +49,9 @@ install: lib{{ basename }}.so lib{{ basename }}.a docs
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/lib/pkgconfig
 
 	$(INSTALL) -m 0644 "{{ basename }}.pc" "$(DESTDIR)/$(PREFIX)/lib/pkgconfig/"
-ifeq ($(shell uname), Darwin)
-	# macOS sed requires backup extension or empty string
-	sed -i '' -e 's^@@PREFIX@@^$(PREFIX)^g' \
+	sed -i.bak -e 's^@@PREFIX@@^$(PREFIX)^g' \
 		"$(DESTDIR)/$(PREFIX)/lib/pkgconfig/{{ basename }}.pc"
-else
-	sed -i -e 's^@@PREFIX@@^$(PREFIX)^g' \
-		"$(DESTDIR)/$(PREFIX)/lib/pkgconfig/{{ basename }}.pc"
-endif
+	rm -f "$(DESTDIR)/$(PREFIX)/lib/pkgconfig/{{ basename }}.pc.bak"
 
 	# Headers
 	$(INSTALL) -d "$(DESTDIR)/$(PREFIX)/include/{{ basename }}"

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -2,51 +2,18 @@
 # Users can still override by setting CXX environment variable
 ifeq ($(shell uname), Darwin)
     # Find the latest g++ version from Homebrew using which (works on both Intel and Apple Silicon)
-    # Try versions from 20 down to 10
-    ifeq ($(shell which g++-20 2>/dev/null),)
-        ifeq ($(shell which g++-19 2>/dev/null),)
-            ifeq ($(shell which g++-18 2>/dev/null),)
-                ifeq ($(shell which g++-17 2>/dev/null),)
-                    ifeq ($(shell which g++-16 2>/dev/null),)
-                        ifeq ($(shell which g++-15 2>/dev/null),)
-                            ifeq ($(shell which g++-14 2>/dev/null),)
-                                ifeq ($(shell which g++-13 2>/dev/null),)
-                                    ifeq ($(shell which g++-12 2>/dev/null),)
-                                        ifeq ($(shell which g++-11 2>/dev/null),)
-                                            ifeq ($(shell which g++-10 2>/dev/null),)
-                                                CXX?=g++
-                                            else
-                                                CXX?=g++-10
-                                            endif
-                                        else
-                                            CXX?=g++-11
-                                        endif
-                                    else
-                                        CXX?=g++-12
-                                    endif
-                                else
-                                    CXX?=g++-13
-                                endif
-                            else
-                                CXX?=g++-14
-                            endif
-                        else
-                            CXX?=g++-15
-                        endif
-                    else
-                        CXX?=g++-16
-                    endif
-                else
-                    CXX?=g++-17
-                endif
-            else
-                CXX?=g++-18
-            endif
-        else
-            CXX?=g++-19
-        endif
+    # Check versions from 20 down to 10 and pick the first one found
+    CXX_DETECTED := $(shell \
+        for v in 20 19 18 17 16 15 14 13 12 11 10; do \
+            if which g++-$$v >/dev/null 2>&1; then \
+                echo g++-$$v; \
+                break; \
+            fi; \
+        done)
+    ifneq ($(CXX_DETECTED),)
+        CXX?=$(CXX_DETECTED)
     else
-        CXX?=g++-20
+        CXX?=g++
     endif
 else
     CXX?=g++

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,18 +1,18 @@
-# On macOS, g++ is often an alias to clang++, so try to find GNU g++ from Homebrew
+# On macOS, g++ is often an alias to clang++, so try to find g++ from Homebrew
 # Users can still override by setting CXX environment variable
 ifeq ($(shell uname), Darwin)
-CXX_DETECTED := $(shell \
-		for v in 20 19 18 17 16 15 14 13 12 11 10; do \
-			if which g++-$$v >/dev/null 2>&1; then \
-				echo g++-$$v; \
-				break; \
-			fi; \
-		done)
-ifneq ($(CXX_DETECTED),)
-CXX?=$(CXX_DETECTED)
-else
-CXX?=g++
-endif
+    CXX_DETECTED := $(shell \
+        for v in 20 19 18 17 16 15 14 13 12 11 10; do \
+            if which g++-$$v >/dev/null 2>&1; then \
+                echo g++-$$v; \
+                break; \
+            fi; \
+        done)
+    ifneq ($(CXX_DETECTED),)
+        CXX?=$(CXX_DETECTED)
+    else
+        CXX?=g++
+    endif
 else
     CXX?=g++
 endif

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,4 +1,8 @@
+ifeq ($(shell uname), Darwin)
+CXX?=clang++
+else
 CXX?=g++
+endif
 CPPFLAGS=
 CXXFLAGS=
 LDFLAGS=

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,18 +1,18 @@
 # On macOS, g++ is often an alias to clang++, so try to find GNU g++ from Homebrew
 # Users can still override by setting CXX environment variable
 ifeq ($(shell uname), Darwin)
-	CXX_DETECTED := $(shell \
+CXX_DETECTED := $(shell \
 		for v in 20 19 18 17 16 15 14 13 12 11 10; do \
 			if which g++-$$v >/dev/null 2>&1; then \
 				echo g++-$$v; \
 				break; \
 			fi; \
 		done)
-	ifneq ($(CXX_DETECTED),)
-		CXX?=$(CXX_DETECTED)
-	else
-	CXX?=g++
-	endif
+ifneq ($(CXX_DETECTED),)
+CXX?=$(CXX_DETECTED)
+else
+CXX?=g++
+endif
 else
     CXX?=g++
 endif

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -31,24 +31,24 @@ install: lib{{ basename }}.so lib{{ basename }}.a docs
 	# Package Config
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/lib/pkgconfig
 
-	$(INSTALL) -m 0644 {{ basename }}.pc $(DESTDIR)/$(PREFIX)/lib/pkgconfig/
+	$(INSTALL) -m 0644 "{{ basename }}.pc" "$(DESTDIR)/$(PREFIX)/lib/pkgconfig/"
 	sed -i -e 's^@@PREFIX@@^$(PREFIX)^g' \
-		$(DESTDIR)/$(PREFIX)/lib/pkgconfig/{{ basename }}.pc
+		"$(DESTDIR)/$(PREFIX)/lib/pkgconfig/{{ basename }}.pc"
 
 	# Headers
-	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/include/{{ basename }}
+	$(INSTALL) -d "$(DESTDIR)/$(PREFIX)/include/{{ basename }}"
 	{%- for h in headers %}
-	$(INSTALL) -m 0644 {{ h }} $(DESTDIR)/$(PREFIX)/include/{{ basename }}/
+	$(INSTALL) -m 0644 "{{ h }}" "$(DESTDIR)/$(PREFIX)/include/{{ basename }}/"
 	{%- endfor %}
 
 	# Binaries
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/bin
 
-	$(INSTALL) -m 0755 {{ basename }}-validate $(DESTDIR)/$(PREFIX)/bin/
+	$(INSTALL) -m 0755 "{{ basename }}-validate" "$(DESTDIR)/$(PREFIX)/bin/"
 
 	# Documentation
-	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/share/doc/lib{{ basename }}
-	$(COPY) -R doc/ $(DESTDIR)/$(PREFIX)/share/doc/lib{{ basename }}/
+	$(INSTALL) -d "$(DESTDIR)/$(PREFIX)/share/doc/lib{{ basename }}"
+	$(COPY) -R doc/ "$(DESTDIR)/$(PREFIX)/share/doc/lib{{ basename }}/"
 
 %.o: %.cpp
 	@echo " [CC]  $<"

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,12 +1,4 @@
-ifeq ($(shell uname), Darwin)
-CXX?=$(shell \
-	if command -v g++-15 >/dev/null 2>&1; then echo g++-15; \
-	elif command -v g++-14 >/dev/null 2>&1; then echo g++-14; \
-	elif command -v g++-13 >/dev/null 2>&1; then echo g++-13; \
-	else echo g++; fi)
-else
 CXX?=g++
-endif
 CPPFLAGS=
 CXXFLAGS=
 LDFLAGS=
@@ -30,11 +22,11 @@ clean:
 install: lib{{ basename }}.so lib{{ basename }}.a docs
 	# Library
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/lib
-	$(INSTALL) -m 0755 lib{{ basename }}.so $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so.{{ lib_version }}
-	ln -sf lib{{ basename }}.so.{{ lib_version }} $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so
-	ln -sf lib{{ basename }}.so.{{ lib_version }} $(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so.{{ lib_version.split(".")[0] }}
+	$(INSTALL) -m 0755 "lib{{ basename }}.so" "$(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so.{{ lib_version }}"
+	ln -sf "lib{{ basename }}.so.{{ lib_version }}" "$(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so"
+	ln -sf "lib{{ basename }}.so.{{ lib_version }}" "$(DESTDIR)/$(PREFIX)/lib/lib{{ basename }}.so.{{ lib_version.split(".")[0] }}"
 
-	$(INSTALL) -m 0644 lib{{ basename }}.a $(DESTDIR)/$(PREFIX)/lib/
+	$(INSTALL) -m 0644 "lib{{ basename }}.a" "$(DESTDIR)/$(PREFIX)/lib/"
 
 	# Package Config
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/lib/pkgconfig
@@ -72,18 +64,18 @@ lib{{ basename }}.a: $(LIB_OBJS)
 	# otherwise the linker may only include object files that were actually
 	# referenced and the initializers will not run
 	@echo " [CXX]  lib{{ basename }}.static.o"
-	$(CXX) -r -o lib{{ basename }}.static.o $^
+	$(CXX) -r -o "lib{{ basename }}.static.o" $^
 	@echo " [AR]  $@"
-	$(AR) rcs $@ lib{{ basename }}.static.o
+	$(AR) rcs $@ "lib{{ basename }}.static.o"
 
 lib{{ basename }}.so: $(LIB_OBJS)
 	@echo " [LD]  $@"
 ifeq ($(shell uname), Darwin)
 	# macOS ld doesn't support -soname; avoid passing it and use -dynamiclib
 	# Set install_name to @rpath/... so client binaries can locate the library
-	$(CXX) -dynamiclib $(LDFLAGS) -Wl,-install_name,@rpath/lib{{ basename }}.so -o $@ $^
+	$(CXX) -dynamiclib $(LDFLAGS) '-Wl,-install_name,@rpath/lib{{ basename }}.so' -o $@ $^
 else
-	$(CXX) -shared -fPIC -Wl,-soname,lib{{ basename }}.so.{{ lib_version.split(".")[0] }} $(LDFLAGS) -o $@ $^
+	$(CXX) -shared -fPIC '-Wl,-soname,lib{{ basename }}.so.{{ lib_version.split(".")[0] }}' $(LDFLAGS) -o $@ $^
 endif
 
 {{ basename }}-validate: $(VALIDATE_OBJS) lib{{ basename }}.a

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -1,8 +1,6 @@
 # On macOS, g++ is often an alias to clang++, so try to find GNU g++ from Homebrew
 # Users can still override by setting CXX environment variable
 ifeq ($(shell uname), Darwin)
-    # Find the latest g++ version from Homebrew using which (works on both Intel and Apple Silicon)
-    # Check versions from 20 down to 10 and pick the first one found
     CXX_DETECTED := $(shell \
         for v in 20 19 18 17 16 15 14 13 12 11 10; do \
             if which g++-$$v >/dev/null 2>&1; then \

--- a/src/shacl2code/lang/templates/cpp/Makefile.j2
+++ b/src/shacl2code/lang/templates/cpp/Makefile.j2
@@ -32,8 +32,14 @@ install: lib{{ basename }}.so lib{{ basename }}.a docs
 	$(INSTALL) -d $(DESTDIR)/$(PREFIX)/lib/pkgconfig
 
 	$(INSTALL) -m 0644 "{{ basename }}.pc" "$(DESTDIR)/$(PREFIX)/lib/pkgconfig/"
+ifeq ($(shell uname), Darwin)
+	# macOS sed requires backup extension or empty string
+	sed -i '' -e 's^@@PREFIX@@^$(PREFIX)^g' \
+		"$(DESTDIR)/$(PREFIX)/lib/pkgconfig/{{ basename }}.pc"
+else
 	sed -i -e 's^@@PREFIX@@^$(PREFIX)^g' \
 		"$(DESTDIR)/$(PREFIX)/lib/pkgconfig/{{ basename }}.pc"
+endif
 
 	# Headers
 	$(INSTALL) -d "$(DESTDIR)/$(PREFIX)/include/{{ basename }}"

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -3,17 +3,19 @@
 #
 # SPDX-License-Identifier: MIT
 
+from dataclasses import dataclass
+from enum import Enum
 import json
+import multiprocessing
 import os
-import pytest
+from pathlib import Path
 import re
 import shutil
 import subprocess
 import textwrap
-import multiprocessing
-from pathlib import Path
-from enum import Enum
-from dataclasses import dataclass
+
+import pytest
+
 from testfixtures import jsonvalidation
 
 THIS_FILE = Path(__file__)
@@ -31,31 +33,24 @@ SPDX3_CONTEXT_URL = "https://spdx.github.io/spdx-3-model/context.json"
 def get_default_cxx():
     """
     Get the default C++ compiler.
-    On macOS, try to find GNU g++ from Homebrew by discovering available versions
-    and picking the latest one, instead of using 'g++' which is an alias to clang++.
+    On macOS, try to find GNU g++ from Homebrew.
     On other platforms, use 'g++'.
     """
-    # If CXX is already set in environment, use it
     cxx = os.environ.get("CXX")
     if cxx:
         return cxx
 
-    # On macOS, g++ is often an alias to clang++, so we need to find the real GNU g++
     if os.uname().sysname == "Darwin":
-        # Try to find g++ from Homebrew by checking which versions are available
-        # This works on both Apple Silicon (/opt/homebrew/bin) and Intel (/usr/local/bin)
         versions = []
-        for version in range(20, 9, -1):  # Check versions 20 down to 10
+        for version in range(20, 9, -1):
             compiler = f"g++-{version}"
             if shutil.which(compiler):
                 versions.append((version, compiler))
 
-        # Return the latest version found
         if versions:
             versions.sort(reverse=True)
             return versions[0][1]
 
-    # Default to g++ on Linux or if no versioned g++ found on macOS
     return "g++"
 
 

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -114,7 +114,7 @@ def build_lib(tmp_path_factory, model_server, tmpname, *, namespace=None):
     pkg_config = tmp_directory / "pkg-config"
     pkg_config.write_text(textwrap.dedent(f"""\
             #! /bin/sh
-            export PKG_CONFIG_PATH="{ str(install_dir / 'lib' / 'pkgconfig') }"
+            export PKG_CONFIG_PATH="{str(install_dir / 'lib' / 'pkgconfig')}"
             exec pkg-config "$@"
             """))
     pkg_config.chmod(0o755)
@@ -1308,7 +1308,7 @@ def test_roundtrip(compile_test, tmp_path, roundtrip):
         SHACLObjectSet objs;
         {{
             std::ifstream infile;
-            infile.open("{ roundtrip }");
+            infile.open("{roundtrip}");
 
             JSONLDDeserializer d;
             d.read(infile, objs);
@@ -1316,7 +1316,7 @@ def test_roundtrip(compile_test, tmp_path, roundtrip):
         }}
         {{
             std::ofstream outfile;
-            outfile.open("{ out_file }");
+            outfile.open("{out_file}");
 
             JSONLDInlineSerializer s;
             s.write(outfile, objs);
@@ -1341,7 +1341,7 @@ def test_static(compile_test, tmp_path, roundtrip):
         SHACLObjectSet objs;
         {{
             std::ifstream infile;
-            infile.open("{ roundtrip }");
+            infile.open("{roundtrip}");
 
             JSONLDDeserializer d;
             d.read(infile, objs);
@@ -1349,7 +1349,7 @@ def test_static(compile_test, tmp_path, roundtrip):
         }}
         {{
             std::ofstream outfile;
-            outfile.open("{ out_file }");
+            outfile.open("{out_file}");
 
             JSONLDInlineSerializer s;
             s.write(outfile, objs);
@@ -1422,7 +1422,7 @@ def test_json_validation(passes, data, tmp_path, test_lib, test_context_url):
     data_file.write_text(json.dumps(data))
     p = subprocess.run(
         [
-            test_lib.bindir / f"{ test_lib.basename }-validate",
+            test_lib.bindir / f"{test_lib.basename}-validate",
             data_file,
         ]
     )
@@ -1441,7 +1441,7 @@ def test_json_types(passes, data, tmp_path, test_lib, test_context_url):
     data_file.write_text(json.dumps(data))
     p = subprocess.run(
         [
-            test_lib.bindir / f"{ test_lib.basename }-validate",
+            test_lib.bindir / f"{test_lib.basename}-validate",
             data_file,
         ]
     )

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -177,12 +177,20 @@ def compile_test(test_lib, tmp_path):
             # On macOS the linker doesn't support -Bstatic/-Bdynamic flags.
             # Use the static archive directly when running on Darwin.
             if os.uname().sysname == "Darwin":
-                static_lib = tmp_path.parent / (test_lib.directory.name) / "install" / "lib" / f"lib{test_lib.basename}.a"
+                static_lib = (
+                    tmp_path.parent
+                    / (test_lib.directory.name)
+                    / "install"
+                    / "lib"
+                    / f"lib{test_lib.basename}.a"
+                )
                 pkg_cflags = f"$({test_lib.pkg_config} --cflags {test_lib.basename})"
-                compile_cmd.extend([
-                    pkg_cflags,
-                    str(static_lib),
-                ])
+                compile_cmd.extend(
+                    [
+                        pkg_cflags,
+                        str(static_lib),
+                    ]
+                )
             else:
                 compile_cmd.extend(
                     [

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -178,8 +178,7 @@ def compile_test(test_lib, tmp_path):
             # Use the static archive directly when running on Darwin.
             if os.uname().sysname == "Darwin":
                 static_lib = (
-                    tmp_path.parent
-                    / (test_lib.directory.name)
+                    test_lib.directory
                     / "install"
                     / "lib"
                     / f"lib{test_lib.basename}.a"

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -114,15 +114,11 @@ def build_lib(tmp_path_factory, model_server, tmpname, *, namespace=None):
         cwd=tmp_directory,
     )
     pkg_config = tmp_directory / "pkg-config"
-    pkg_config.write_text(
-        textwrap.dedent(
-            f"""\
+    pkg_config.write_text(textwrap.dedent(f"""\
             #! /bin/sh
             export PKG_CONFIG_PATH="{ str(install_dir / 'lib' / 'pkgconfig') }"
             exec pkg-config "$@"
-            """
-        )
-    )
+            """))
     pkg_config.chmod(0o755)
 
     return Lib(
@@ -155,8 +151,7 @@ def compile_test(test_lib, tmp_path):
     def f(code_fragment, *, progress=Progress.RUNS, static=False):
         src = tmp_path / "test.cpp"
         src.write_text(
-            textwrap.dedent(
-                f"""\
+            textwrap.dedent(f"""\
                 #include "{test_lib.basename}/{test_lib.basename}.hpp"
                 #include "{test_lib.basename}/{test_lib.basename}-jsonld.hpp"
                 #include <iostream>
@@ -167,29 +162,24 @@ def compile_test(test_lib, tmp_path):
 
                 int main(int argc, char** argv) {{
                     try {{
-                """
-            )
+                """)
             + textwrap.dedent(code_fragment)
             + "".join(
-                textwrap.dedent(
-                    f"""\
+                textwrap.dedent(f"""\
                     }} catch ({exc}& e) {{
                         std::cout << " {enum.name} " << e.what() << std::endl;
                         return 1;
-                    """
-                )
+                    """)
                 for exc, enum in (
                     ("ValidationError", Progress.VALIDATION_FAILS),
                     ("std::bad_cast", Progress.CAST_FAILS),
                 )
             )
-            + textwrap.dedent(
-                """\
+            + textwrap.dedent("""\
                     }
                     return 0;
                 }
-                """
-            )
+                """)
         )
 
         prog = tmp_path / "prog"
@@ -211,10 +201,7 @@ def compile_test(test_lib, tmp_path):
             # Use the static archive directly when running on Darwin.
             if os.uname().sysname == "Darwin":
                 static_lib = (
-                    test_lib.directory
-                    / "install"
-                    / "lib"
-                    / f"lib{test_lib.basename}.a"
+                    test_lib.directory / "install" / "lib" / f"lib{test_lib.basename}.a"
                 )
                 pkg_cflags = f"$({test_lib.pkg_config} --cflags {test_lib.basename})"
                 compile_cmd.extend(
@@ -240,14 +227,10 @@ def compile_test(test_lib, tmp_path):
             )
 
         compile_script = tmp_path / "compile.sh"
-        compile_script.write_text(
-            textwrap.dedent(
-                f"""\
+        compile_script.write_text(textwrap.dedent(f"""\
                 #! /bin/sh
                 exec {" ".join(str(s) for s in compile_cmd)}
-                """
-            )
-        )
+                """))
         compile_script.chmod(0o755)
 
         p = subprocess.run(
@@ -413,17 +396,13 @@ def test_compile(compile_test):
 def test_headers(test_lib, tmp_path):
     for h in test_lib.directory.glob("*.hpp"):
         src = tmp_path / (h.name + ".cpp")
-        src.write_text(
-            textwrap.dedent(
-                f"""\
+        src.write_text(textwrap.dedent(f"""\
                 #include <{test_lib.basename}/{h.name}>
 
                 int main(int argc, char** argv) {{
                     return 0;
                 }}
-                """
-            )
-        )
+                """))
 
         prog = tmp_path / "prog"
         pkg_config_cmd = f"$({test_lib.pkg_config} --cflags --libs {test_lib.basename})"
@@ -442,14 +421,10 @@ def test_headers(test_lib, tmp_path):
         ]
 
         compile_script = tmp_path / "compile.sh"
-        compile_script.write_text(
-            textwrap.dedent(
-                f"""\
+        compile_script.write_text(textwrap.dedent(f"""\
                 #! /bin/sh
                 exec {" ".join(str(s) for s in compile_cmd)}
-                """
-            )
-        )
+                """))
         compile_script.chmod(0o755)
 
         subprocess.run(
@@ -767,12 +742,10 @@ def test_class_prop_validation(compile_test, prop, value, expect):
 )
 def test_ref_implicit_cast(compile_test, A, B, progress):
     # Check types are valid
-    compile_test(
-        f"""\
+    compile_test(f"""\
         auto a = make_obj<{A}>();
         auto b = make_obj<{B}>();
-        """
-    )
+        """)
 
     output = compile_test(
         f"""\
@@ -805,32 +778,27 @@ def test_ref_implicit_cast(compile_test, A, B, progress):
         assert output.rstrip() == "_:foo"
 
     if progress == Progress.RUNS:
-        output = compile_test(
-            f"""\
+        output = compile_test(f"""\
             Ref<{A}> a("_:foo");
             Ref<{B}> b(a);
 
             std::cout << b.iri() << std::endl;
-            """
-        )
+            """)
         assert output.rstrip() == "_:foo"
 
-        output = compile_test(
-            f"""\
+        output = compile_test(f"""\
             Ref<{A}> a("_:foo");
             Ref<{B}> b("_:bar");
             b = a;
             a.isObj();
 
             std::cout << b.iri() << std::endl;
-            """
-        )
+            """)
         assert output.rstrip() == "_:foo"
 
 
 def test_ref_prop_assignment(compile_test):
-    output = compile_test(
-        """\
+    output = compile_test("""\
         auto c = make_obj<test_class>();
         c->_test_class_class_prop = make_obj<test_class>();
         c->_test_class_class_prop->_id = "_:foo";
@@ -839,32 +807,27 @@ def test_ref_prop_assignment(compile_test):
         d->_test_class_class_prop = c->_test_class_class_prop;
 
         std::cout << d->_test_class_class_prop->_id.get() << std::endl;
-        """
-    )
+        """)
 
     assert output.rstrip() == "_:foo"
 
 
 def test_ref_implicit_cast_to_abstract(compile_test):
-    output = compile_test(
-        """\
+    output = compile_test("""\
         auto r = make_obj<concrete_class>();
         r->_id = "_:foo";
         Ref<abstract_class> p(r);
 
         std::cout << p->_id.get() << std::endl;
-        """
-    )
+        """)
     assert output.rstrip() == "_:foo"
 
-    output = compile_test(
-        """\
+    output = compile_test("""\
         Ref<concrete_class> a("_:foo");
         Ref<abstract_class> b(a);
 
         std::cout << b.iri() << std::endl;
-        """
-    )
+        """)
     assert output.rstrip() == "_:foo"
 
 
@@ -881,12 +844,10 @@ def test_ref_implicit_cast_to_abstract(compile_test):
 )
 def test_ref_explicit_cast(compile_test, A, B, progress):
     # Check types are valid
-    compile_test(
-        f"""\
+    compile_test(f"""\
         auto a = make_obj<{A}>();
         auto b = make_obj<{B}>();
-        """
-    )
+        """)
 
     output = compile_test(
         f"""\
@@ -916,24 +877,20 @@ def test_ref_explicit_cast(compile_test, A, B, progress):
         assert output.rstrip() == "_:foo"
 
     if progress == Progress.RUNS:
-        output = compile_test(
-            f"""\
+        output = compile_test(f"""\
             Ref<{A}> a("_:foo");
             auto b = a.asTypeRef<{B}>();
             std::cout << b.iri() << std::endl;
-            """
-        )
+            """)
         assert output.rstrip() == "_:foo"
 
-        output = compile_test(
-            f"""\
+        output = compile_test(f"""\
             Ref<{A}> a("_:foo");
             Ref<{B}> b("bar");
             b = a.asTypeRef<{B}>();
 
             std::cout << b.iri() << std::endl;
-            """
-        )
+            """)
         assert output.rstrip() == "_:foo"
 
 
@@ -948,45 +905,37 @@ def test_ref_explicit_cast_to_derived(compile_test):
     )
 
     # Passes because it is a string reference
-    output = compile_test(
-        """\
+    output = compile_test("""\
         Ref<test_class> r("_:foo");
         auto p = r.asTypeRef<test_derived_class>();
         std::cout << p.iri() << std::endl;
-        """
-    )
+        """)
     assert output.rstrip() == "_:foo"
 
     # Passes because r is actually a test_derived_class
-    compile_test(
-        """\
+    compile_test("""\
         auto r = make_obj<test_derived_class>();
         auto i = r.asTypeRef<parent_class>();
         auto p = i.asTypeRef<test_derived_class>();
-        """
-    )
+        """)
 
-    output = compile_test(
-        """\
+    output = compile_test("""\
         Ref<test_derived_class> r("_:foo");
         auto i = r.asTypeRef<test_class>();
         auto p = i.asTypeRef<test_derived_class>();
         std::cout << p.iri() << std::endl;
-        """
-    )
+        """)
     assert output.rstrip() == "_:foo"
 
 
 def test_ref_explicit_cast_to_abstract(compile_test):
-    output = compile_test(
-        """\
+    output = compile_test("""\
         auto r = make_obj<concrete_class>();
         r->_id = "_:foo";
         auto p = r.asTypeRef<abstract_class>();
 
         std::cout << r->_id.get() << std::endl;
-        """
-    )
+        """)
     assert output.rstrip() == "_:foo"
 
 
@@ -1003,21 +952,17 @@ def test_ref_explicit_cast_to_abstract(compile_test):
 )
 def test_DateTime_toString(compile_test, create_args, expect, tzoffset):
     args = ", ".join(repr(r) for r in create_args)
-    output = compile_test(
-        f"""\
+    output = compile_test(f"""\
         std::cout << DateTime({args}).toString() << std::endl;
-        """
-    )
+        """)
 
     assert (
         output.rstrip() == expect
     ), f"Bad string result for DateTime({args}).toString(). Expected {expect!r}. Got {output.rstrip()!r}"
 
-    output = compile_test(
-        f"""\
+    output = compile_test(f"""\
         std::cout << DateTime({args}).tzOffsetSeconds() << std::endl;
-        """
-    )
+        """)
 
     assert (
         int(output.rstrip()) == tzoffset
@@ -1051,8 +996,7 @@ def test_DateTime_toString(compile_test, create_args, expect, tzoffset):
     ],
 )
 def test_DateTime_fromString(compile_test, s, valid, time, tzoffset):
-    output = compile_test(
-        f"""
+    output = compile_test(f"""
         auto d = DateTime::fromString("{s}", true);
         if (d) {{
             auto dt = d.value();
@@ -1061,8 +1005,7 @@ def test_DateTime_fromString(compile_test, s, valid, time, tzoffset):
         }} else {{
             std::cout << "INVALID" << std::endl;
         }}
-        """
-    )
+        """)
 
     if valid:
         expect = [str(time), str(tzoffset)]
@@ -1082,8 +1025,7 @@ def test_abstract_class(compile_test):
 
 
 def test_id_alias(compile_test):
-    output = compile_test(
-        """\
+    output = compile_test("""\
         {
             auto c = make_obj<inherited_id_prop_class>();
             std::cout << c->_id.getIRI() << std::endl;
@@ -1104,8 +1046,7 @@ def test_id_alias(compile_test):
             auto b = c.asTypeRef<SHACLObject>();
             std::cout << b->_id.getIRI() << std::endl;
         }
-        """
-    )
+        """)
     expected = ["testid"] * 3 + ["@id"] * 3
     assert (
         output.splitlines() == expected
@@ -1113,8 +1054,7 @@ def test_id_alias(compile_test):
 
 
 def test_mandatory_properties(compile_test, tmp_path):
-    CODE = textwrap.dedent(
-        """\
+    CODE = textwrap.dedent("""\
         auto c = make_obj<test_class_required>();
         c->_id = "_:blank";
         c->_test_class_required_string_scalar_prop = "foo";
@@ -1131,8 +1071,7 @@ def test_mandatory_properties(compile_test, tmp_path):
         JSONLDInlineSerializer s;
         s.write(outfile, o);
         outfile.close();
-        """
-    )
+        """)
 
     # Verify that the base code works
     compile_test(CODE.format(code="", fn=tmp_path / "pass.json"))
@@ -1174,8 +1113,7 @@ def test_mandatory_properties(compile_test, tmp_path):
 @pytest.fixture
 def iterator_test(compile_test):
     def f(code, expect):
-        output = compile_test(
-            f"""\
+        output = compile_test(f"""\
             auto c = make_obj<test_class>();
             auto& p = c->_test_class_string_list_prop;
             {textwrap.dedent(code)}
@@ -1183,8 +1121,7 @@ def iterator_test(compile_test):
             for (auto&& i : p) {{
                 std::cout << i << std::endl;
             }}
-            """
-        )
+            """)
         assert output.splitlines() == expect
 
     return f
@@ -1314,16 +1251,14 @@ class TestListIterators:
         )
 
     def test_std_find(self, compile_test):
-        output = compile_test(
-            """\
+        output = compile_test("""\
             auto c = make_obj<test_class>();
             auto& p = c->_test_class_string_list_prop;
 
             p.insert(p.begin(), {"A", "B", "C"});
             auto it = std::find(p.begin(), p.end(), "A");
             std::cout << *it << std::endl;
-            """
-        )
+            """)
         assert output.splitlines() + ["A"]
 
     def test_std_remove(self, iterator_test):
@@ -1371,8 +1306,7 @@ class TestListIterators:
 def test_roundtrip(compile_test, tmp_path, roundtrip):
     out_file = tmp_path / "out.json"
 
-    compile_test(
-        f"""\
+    compile_test(f"""\
         SHACLObjectSet objs;
         {{
             std::ifstream infile;
@@ -1390,8 +1324,7 @@ def test_roundtrip(compile_test, tmp_path, roundtrip):
             s.write(outfile, objs);
             outfile.close();
         }}
-        """
-    )
+        """)
 
     with roundtrip.open("r") as f:
         expect = json.load(f)
@@ -1430,22 +1363,19 @@ def test_static(compile_test, tmp_path, roundtrip):
 
 
 def test_set(compile_test):
-    output = compile_test(
-        """
+    output = compile_test("""
         auto c = make_obj<test_class>();
         c->set<&SHACLObject::_id>("_:foo").set<&test_class::_test_class_string_scalar_prop>("b");
 
         std::cout << c->_id.get() << std::endl;
         std::cout << c->_test_class_string_scalar_prop.get() << std::endl;
-        """
-    )
+        """)
 
     assert output.splitlines() == ["_:foo", "b"]
 
 
 def test_add(compile_test):
-    output = compile_test(
-        """
+    output = compile_test("""
         auto c = make_obj<test_class>();
         c->add<&test_class::_test_class_string_list_prop>("a").add<&test_class::_test_class_string_list_prop>("b");
 
@@ -1453,8 +1383,7 @@ def test_add(compile_test):
             std::cout << i << std::endl;
         }
 
-        """
-    )
+        """)
 
     assert output.splitlines() == ["a", "b"]
 

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -112,11 +112,15 @@ def build_lib(tmp_path_factory, model_server, tmpname, *, namespace=None):
         cwd=tmp_directory,
     )
     pkg_config = tmp_directory / "pkg-config"
-    pkg_config.write_text(textwrap.dedent(f"""\
+    pkg_config.write_text(
+        textwrap.dedent(
+            f"""\
             #! /bin/sh
             export PKG_CONFIG_PATH="{str(install_dir / 'lib' / 'pkgconfig')}"
             exec pkg-config "$@"
-            """))
+            """
+        )
+    )
     pkg_config.chmod(0o755)
 
     return Lib(
@@ -149,7 +153,8 @@ def compile_test(test_lib, tmp_path):
     def f(code_fragment, *, progress=Progress.RUNS, static=False):
         src = tmp_path / "test.cpp"
         src.write_text(
-            textwrap.dedent(f"""\
+            textwrap.dedent(
+                f"""\
                 #include "{test_lib.basename}/{test_lib.basename}.hpp"
                 #include "{test_lib.basename}/{test_lib.basename}-jsonld.hpp"
                 #include <iostream>
@@ -160,24 +165,29 @@ def compile_test(test_lib, tmp_path):
 
                 int main(int argc, char** argv) {{
                     try {{
-                """)
+                """
+            )
             + textwrap.dedent(code_fragment)
             + "".join(
-                textwrap.dedent(f"""\
+                textwrap.dedent(
+                    f"""\
                     }} catch ({exc}& e) {{
                         std::cout << " {enum.name} " << e.what() << std::endl;
                         return 1;
-                    """)
+                    """
+                )
                 for exc, enum in (
                     ("ValidationError", Progress.VALIDATION_FAILS),
                     ("std::bad_cast", Progress.CAST_FAILS),
                 )
             )
-            + textwrap.dedent("""\
+            + textwrap.dedent(
+                """\
                     }
                     return 0;
                 }
-                """)
+                """
+            )
         )
 
         prog = tmp_path / "prog"
@@ -225,10 +235,14 @@ def compile_test(test_lib, tmp_path):
             )
 
         compile_script = tmp_path / "compile.sh"
-        compile_script.write_text(textwrap.dedent(f"""\
+        compile_script.write_text(
+            textwrap.dedent(
+                f"""\
                 #! /bin/sh
                 exec {" ".join(str(s) for s in compile_cmd)}
-                """))
+                """
+            )
+        )
         compile_script.chmod(0o755)
 
         p = subprocess.run(
@@ -394,13 +408,17 @@ def test_compile(compile_test):
 def test_headers(test_lib, tmp_path):
     for h in test_lib.directory.glob("*.hpp"):
         src = tmp_path / (h.name + ".cpp")
-        src.write_text(textwrap.dedent(f"""\
+        src.write_text(
+            textwrap.dedent(
+                f"""\
                 #include <{test_lib.basename}/{h.name}>
 
                 int main(int argc, char** argv) {{
                     return 0;
                 }}
-                """))
+                """
+            )
+        )
 
         prog = tmp_path / "prog"
         pkg_config_cmd = f"$({test_lib.pkg_config} --cflags --libs {test_lib.basename})"
@@ -419,10 +437,14 @@ def test_headers(test_lib, tmp_path):
         ]
 
         compile_script = tmp_path / "compile.sh"
-        compile_script.write_text(textwrap.dedent(f"""\
+        compile_script.write_text(
+            textwrap.dedent(
+                f"""\
                 #! /bin/sh
                 exec {" ".join(str(s) for s in compile_cmd)}
-                """))
+                """
+            )
+        )
         compile_script.chmod(0o755)
 
         subprocess.run(
@@ -740,10 +762,12 @@ def test_class_prop_validation(compile_test, prop, value, expect):
 )
 def test_ref_implicit_cast(compile_test, A, B, progress):
     # Check types are valid
-    compile_test(f"""\
+    compile_test(
+        f"""\
         auto a = make_obj<{A}>();
         auto b = make_obj<{B}>();
-        """)
+        """
+    )
 
     output = compile_test(
         f"""\
@@ -776,27 +800,32 @@ def test_ref_implicit_cast(compile_test, A, B, progress):
         assert output.rstrip() == "_:foo"
 
     if progress == Progress.RUNS:
-        output = compile_test(f"""\
+        output = compile_test(
+            f"""\
             Ref<{A}> a("_:foo");
             Ref<{B}> b(a);
 
             std::cout << b.iri() << std::endl;
-            """)
+            """
+        )
         assert output.rstrip() == "_:foo"
 
-        output = compile_test(f"""\
+        output = compile_test(
+            f"""\
             Ref<{A}> a("_:foo");
             Ref<{B}> b("_:bar");
             b = a;
             a.isObj();
 
             std::cout << b.iri() << std::endl;
-            """)
+            """
+        )
         assert output.rstrip() == "_:foo"
 
 
 def test_ref_prop_assignment(compile_test):
-    output = compile_test("""\
+    output = compile_test(
+        """\
         auto c = make_obj<test_class>();
         c->_test_class_class_prop = make_obj<test_class>();
         c->_test_class_class_prop->_id = "_:foo";
@@ -805,27 +834,32 @@ def test_ref_prop_assignment(compile_test):
         d->_test_class_class_prop = c->_test_class_class_prop;
 
         std::cout << d->_test_class_class_prop->_id.get() << std::endl;
-        """)
+        """
+    )
 
     assert output.rstrip() == "_:foo"
 
 
 def test_ref_implicit_cast_to_abstract(compile_test):
-    output = compile_test("""\
+    output = compile_test(
+        """\
         auto r = make_obj<concrete_class>();
         r->_id = "_:foo";
         Ref<abstract_class> p(r);
 
         std::cout << p->_id.get() << std::endl;
-        """)
+        """
+    )
     assert output.rstrip() == "_:foo"
 
-    output = compile_test("""\
+    output = compile_test(
+        """\
         Ref<concrete_class> a("_:foo");
         Ref<abstract_class> b(a);
 
         std::cout << b.iri() << std::endl;
-        """)
+        """
+    )
     assert output.rstrip() == "_:foo"
 
 
@@ -842,10 +876,12 @@ def test_ref_implicit_cast_to_abstract(compile_test):
 )
 def test_ref_explicit_cast(compile_test, A, B, progress):
     # Check types are valid
-    compile_test(f"""\
+    compile_test(
+        f"""\
         auto a = make_obj<{A}>();
         auto b = make_obj<{B}>();
-        """)
+        """
+    )
 
     output = compile_test(
         f"""\
@@ -875,20 +911,24 @@ def test_ref_explicit_cast(compile_test, A, B, progress):
         assert output.rstrip() == "_:foo"
 
     if progress == Progress.RUNS:
-        output = compile_test(f"""\
+        output = compile_test(
+            f"""\
             Ref<{A}> a("_:foo");
             auto b = a.asTypeRef<{B}>();
             std::cout << b.iri() << std::endl;
-            """)
+            """
+        )
         assert output.rstrip() == "_:foo"
 
-        output = compile_test(f"""\
+        output = compile_test(
+            f"""\
             Ref<{A}> a("_:foo");
             Ref<{B}> b("bar");
             b = a.asTypeRef<{B}>();
 
             std::cout << b.iri() << std::endl;
-            """)
+            """
+        )
         assert output.rstrip() == "_:foo"
 
 
@@ -903,37 +943,45 @@ def test_ref_explicit_cast_to_derived(compile_test):
     )
 
     # Passes because it is a string reference
-    output = compile_test("""\
+    output = compile_test(
+        """\
         Ref<test_class> r("_:foo");
         auto p = r.asTypeRef<test_derived_class>();
         std::cout << p.iri() << std::endl;
-        """)
+        """
+    )
     assert output.rstrip() == "_:foo"
 
     # Passes because r is actually a test_derived_class
-    compile_test("""\
+    compile_test(
+        """\
         auto r = make_obj<test_derived_class>();
         auto i = r.asTypeRef<parent_class>();
         auto p = i.asTypeRef<test_derived_class>();
-        """)
+        """
+    )
 
-    output = compile_test("""\
+    output = compile_test(
+        """\
         Ref<test_derived_class> r("_:foo");
         auto i = r.asTypeRef<test_class>();
         auto p = i.asTypeRef<test_derived_class>();
         std::cout << p.iri() << std::endl;
-        """)
+        """
+    )
     assert output.rstrip() == "_:foo"
 
 
 def test_ref_explicit_cast_to_abstract(compile_test):
-    output = compile_test("""\
+    output = compile_test(
+        """\
         auto r = make_obj<concrete_class>();
         r->_id = "_:foo";
         auto p = r.asTypeRef<abstract_class>();
 
         std::cout << r->_id.get() << std::endl;
-        """)
+        """
+    )
     assert output.rstrip() == "_:foo"
 
 
@@ -950,17 +998,21 @@ def test_ref_explicit_cast_to_abstract(compile_test):
 )
 def test_DateTime_toString(compile_test, create_args, expect, tzoffset):
     args = ", ".join(repr(r) for r in create_args)
-    output = compile_test(f"""\
+    output = compile_test(
+        f"""\
         std::cout << DateTime({args}).toString() << std::endl;
-        """)
+        """
+    )
 
     assert (
         output.rstrip() == expect
     ), f"Bad string result for DateTime({args}).toString(). Expected {expect!r}. Got {output.rstrip()!r}"
 
-    output = compile_test(f"""\
+    output = compile_test(
+        f"""\
         std::cout << DateTime({args}).tzOffsetSeconds() << std::endl;
-        """)
+        """
+    )
 
     assert (
         int(output.rstrip()) == tzoffset
@@ -994,7 +1046,8 @@ def test_DateTime_toString(compile_test, create_args, expect, tzoffset):
     ],
 )
 def test_DateTime_fromString(compile_test, s, valid, time, tzoffset):
-    output = compile_test(f"""
+    output = compile_test(
+        f"""
         auto d = DateTime::fromString("{s}", true);
         if (d) {{
             auto dt = d.value();
@@ -1003,7 +1056,8 @@ def test_DateTime_fromString(compile_test, s, valid, time, tzoffset):
         }} else {{
             std::cout << "INVALID" << std::endl;
         }}
-        """)
+        """
+    )
 
     if valid:
         expect = [str(time), str(tzoffset)]
@@ -1023,7 +1077,8 @@ def test_abstract_class(compile_test):
 
 
 def test_id_alias(compile_test):
-    output = compile_test("""\
+    output = compile_test(
+        """\
         {
             auto c = make_obj<inherited_id_prop_class>();
             std::cout << c->_id.getIRI() << std::endl;
@@ -1044,7 +1099,8 @@ def test_id_alias(compile_test):
             auto b = c.asTypeRef<SHACLObject>();
             std::cout << b->_id.getIRI() << std::endl;
         }
-        """)
+        """
+    )
     expected = ["testid"] * 3 + ["@id"] * 3
     assert (
         output.splitlines() == expected
@@ -1052,7 +1108,8 @@ def test_id_alias(compile_test):
 
 
 def test_mandatory_properties(compile_test, tmp_path):
-    CODE = textwrap.dedent("""\
+    CODE = textwrap.dedent(
+        """\
         auto c = make_obj<test_class_required>();
         c->_id = "_:blank";
         c->_test_class_required_string_scalar_prop = "foo";
@@ -1069,7 +1126,8 @@ def test_mandatory_properties(compile_test, tmp_path):
         JSONLDInlineSerializer s;
         s.write(outfile, o);
         outfile.close();
-        """)
+        """
+    )
 
     # Verify that the base code works
     compile_test(CODE.format(code="", fn=tmp_path / "pass.json"))
@@ -1111,7 +1169,8 @@ def test_mandatory_properties(compile_test, tmp_path):
 @pytest.fixture
 def iterator_test(compile_test):
     def f(code, expect):
-        output = compile_test(f"""\
+        output = compile_test(
+            f"""\
             auto c = make_obj<test_class>();
             auto& p = c->_test_class_string_list_prop;
             {textwrap.dedent(code)}
@@ -1119,7 +1178,8 @@ def iterator_test(compile_test):
             for (auto&& i : p) {{
                 std::cout << i << std::endl;
             }}
-            """)
+            """
+        )
         assert output.splitlines() == expect
 
     return f
@@ -1249,14 +1309,16 @@ class TestListIterators:
         )
 
     def test_std_find(self, compile_test):
-        output = compile_test("""\
+        output = compile_test(
+            """\
             auto c = make_obj<test_class>();
             auto& p = c->_test_class_string_list_prop;
 
             p.insert(p.begin(), {"A", "B", "C"});
             auto it = std::find(p.begin(), p.end(), "A");
             std::cout << *it << std::endl;
-            """)
+            """
+        )
         assert output.splitlines() + ["A"]
 
     def test_std_remove(self, iterator_test):
@@ -1304,7 +1366,8 @@ class TestListIterators:
 def test_roundtrip(compile_test, tmp_path, roundtrip):
     out_file = tmp_path / "out.json"
 
-    compile_test(f"""\
+    compile_test(
+        f"""\
         SHACLObjectSet objs;
         {{
             std::ifstream infile;
@@ -1322,7 +1385,8 @@ def test_roundtrip(compile_test, tmp_path, roundtrip):
             s.write(outfile, objs);
             outfile.close();
         }}
-        """)
+        """
+    )
 
     with roundtrip.open("r") as f:
         expect = json.load(f)
@@ -1361,19 +1425,22 @@ def test_static(compile_test, tmp_path, roundtrip):
 
 
 def test_set(compile_test):
-    output = compile_test("""
+    output = compile_test(
+        """
         auto c = make_obj<test_class>();
         c->set<&SHACLObject::_id>("_:foo").set<&test_class::_test_class_string_scalar_prop>("b");
 
         std::cout << c->_id.get() << std::endl;
         std::cout << c->_test_class_string_scalar_prop.get() << std::endl;
-        """)
+        """
+    )
 
     assert output.splitlines() == ["_:foo", "b"]
 
 
 def test_add(compile_test):
-    output = compile_test("""
+    output = compile_test(
+        """
         auto c = make_obj<test_class>();
         c->add<&test_class::_test_class_string_list_prop>("a").add<&test_class::_test_class_string_list_prop>("b");
 
@@ -1381,7 +1448,8 @@ def test_add(compile_test):
             std::cout << i << std::endl;
         }
 
-        """)
+        """
+    )
 
     assert output.splitlines() == ["a", "b"]
 

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -42,28 +42,18 @@ def get_default_cxx():
 
     # On macOS, g++ is often an alias to clang++, so we need to find the real GNU g++
     if os.uname().sysname == "Darwin":
-        # Try to find g++ from Homebrew by listing available versions
-        homebrew_bin = Path("/opt/homebrew/bin")
-        if homebrew_bin.exists():
-            # Find all g++-* executables and extract version numbers
-            versions = []
-            for compiler_path in homebrew_bin.glob("g++-*"):
-                try:
-                    # Extract version number from g++-XX
-                    version_str = compiler_path.name[4:]  # Remove 'g++-' prefix
-                    version_num = int(version_str)
-                    versions.append((version_num, compiler_path.name))
-                except (ValueError, IndexError):
-                    # Skip if not a valid version number
-                    continue
+        # Try to find g++ from Homebrew by checking which versions are available
+        # This works on both Apple Silicon (/opt/homebrew/bin) and Intel (/usr/local/bin)
+        versions = []
+        for version in range(20, 9, -1):  # Check versions 20 down to 10
+            compiler = f"g++-{version}"
+            if shutil.which(compiler):
+                versions.append((version, compiler))
 
-            # Sort by version number (descending) and pick the latest
-            if versions:
-                versions.sort(reverse=True)
-                latest_compiler = versions[0][1]
-                # Verify it's actually executable
-                if shutil.which(latest_compiler):
-                    return latest_compiler
+        # Return the latest version found
+        if versions:
+            versions.sort(reverse=True)
+            return versions[0][1]
 
     # Default to g++ on Linux or if no versioned g++ found on macOS
     return "g++"

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -7,6 +7,7 @@ import json
 import os
 import pytest
 import re
+import shutil
 import subprocess
 import textwrap
 import multiprocessing
@@ -44,18 +45,8 @@ def get_default_cxx():
         # Try to find g++ from Homebrew in order of preference
         for version in ["15", "14", "13"]:
             compiler = f"g++-{version}"
-            try:
-                # Check if the compiler exists
-                result = subprocess.run(
-                    ["which", compiler],
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-                if result.returncode == 0:
-                    return compiler
-            except Exception:
-                continue
+            if shutil.which(compiler):
+                return compiler
 
     # Default to g++ on Linux or if no versioned g++ found on macOS
     return "g++"


### PR DESCRIPTION
## Background

- The CXX in configuration is set to g++.
- g++ in macOS is often an alias to clang++. But the current code may not support clang++

## What this PR does

- This PR is trying to make the pytest and the test workflow runnable on both ubuntu-latest and macos-latest. So the test can be run locally and on the GitHub workflow.
- In the template for C++ Makefile generation:
  - Make it possible for the user to define their own CXX environment variable (for example, "CXX=g++-15". If CXX not exist, use the default "g++".)
  - Specifically use g++-1x from brew install
  - Adjust few command lines to use parameters that available in both Linux and Darwin/BSD, or make a branch to run a OS-specific command line.
- In the test suite code:
  - Take existing CXX value from environment variable, if set
  - Adjust few compiler parameters, make it more portable
- In the test workflow:
  - Add the installation of macOS dependencies, including gcc, to make it possible to run the test on macos-latest on GitHub.